### PR TITLE
[fix] Make debugging easier when breaking on caught exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,8 +21,10 @@ function env(environment) {
       env.merge(environment, env.parse(window.name));
     }
 
-    try { env.merge(environment, env.parse(window.localStorage.env || window.localStorage.debug)); }
-    catch (e) {}
+    if (window.localStorage) {
+      try { env.merge(environment, env.parse(window.localStorage.env || window.localStorage.debug)); }
+      catch (e) {}
+    }
 
     if (
          'object' === typeof window.location

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "env-variable",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Cross platform environment variables with process.env, window.name, location.hash and localStorage fallbacks",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I often need to use "break on caught exceptions" to catch RN RSODs before they show the red-screen UI, but with `env-variable` as a dependency I have to continue through this exception constantly.  Checking will eliminate spurious exceptions and make debugging easier.