### PR TITLE
Remove unchecked use of local storage again

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,8 @@ function env(environment) {
       env.merge(environment, env.parse(window.name));
     }
 
-    if (window.localStorage) {
-      try { env.merge(environment, env.parse(window.localStorage.env || window.localStorage.debug)); }
-      catch (e) {}
-    }
+    try { env.merge(environment, env.parse(window.localStorage.env || window.localStorage.debug)); }
+    catch (e) {}
 
     if (
          'object' === typeof window.location

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "env-variable",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Cross platform environment variables with process.env, window.name, location.hash and localStorage fallbacks",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Accessing `window.localStorage` outside of a try catch block causes an exception in private browser sessions with 3rd party cookies disabled. We need to revert the change made for version 0.0.4.