### PR TITLE
window.localStorage needs to be wrapped in try catch on safari Closes: #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,11 @@ function env(environment) {
       env.merge(environment, env.parse(window.name));
     }
 
-    if (window.localStorage) {
-      try { env.merge(environment, env.parse(window.localStorage.env || window.localStorage.debug)); }
-      catch (e) {}
-    }
+    try {
+      if (window.localStorage) {
+        env.merge(environment, env.parse(window.localStorage.env || window.localStorage.debug));
+      }
+    } catch (e) {}
 
     if (
          'object' === typeof window.location


### PR DESCRIPTION
Fixes https://github.com/bigpipe/env-variable/issues/4